### PR TITLE
Bump to go 1.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.so
 *.dylib
 
+# IDE files
+.idea/
+.vscode/
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grpckit/omniproto
 
-go 1.14
+go 1.16
 
 require (
 	github.com/golang/protobuf v1.5.2


### PR DESCRIPTION
1. Bumping from golang 1.14 -> 1.16 
2. Adding IDE files to the `.gitignore`