### PR TITLE
Adding support for --plugin_opt to make larger builds more manageable

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,6 +18,11 @@ type Plugin struct {
 	Name   string
 	Output string
 	Args   string
+	// Each will get rendered as it's own --plugin_opt=arg flag. The plugin
+	// must support this - not all do.
+	//
+	// Ref: https://github.com/protocolbuffers/protobuf/blob/fa5a69e73b0dd667ff15062adbc170310d440ee9/src/google/protobuf/compiler/command_line_interface.h#L174
+	Opts []string
 }
 
 // Config represents an omniproto configuration

--- a/omniproto.yaml
+++ b/omniproto.yaml
@@ -6,7 +6,11 @@ sources: # all sources will be passed together
 output: gen # gen is the default output directory (should be gitignored)
 plugins:
 - name: go # the name of the plugin will be suffixed with _out, i.e. go_out.
-  args: paths=source_relative # args will be passed in to the plugin flag
+  opts:
+    # opts will be passed in to the plugin flag, assuming the plugin supports
+    # --plugin_opt
+    # Ref: https://github.com/protocolbuffers/protobuf/blob/fa5a69e73b0dd667ff15062adbc170310d440ee9/src/google/protobuf/compiler/command_line_interface.h#L174
+    - paths=source_relative 
 - name: validate
   args: lang=go
 - name: python

--- a/protogen.go
+++ b/protogen.go
@@ -21,6 +21,7 @@ func GenProtoString(config *Config) string {
 
 	for _, plugin := range config.Plugins {
 		b.WriteString(fmt.Sprintf("--%v_out=%v%v%v", plugin.Name, getArgs(plugin), getOutputForPlugin(plugin, config), space))
+		b.WriteString(getOpts(plugin))
 	}
 
 	if config.EnableProto3OptionalFields {
@@ -52,6 +53,18 @@ func getArgs(plugin Plugin) string {
 		return fmt.Sprintf("%v:", plugin.Args)
 	}
 	return ""
+}
+
+func getOpts(plugin Plugin) string {
+	if len(plugin.Opts) == 0 {
+		return ""
+	}
+
+	var flags []string
+	for _, opt := range plugin.Opts {
+		flags = append(flags, fmt.Sprintf("--%v_opt=%v", plugin.Name, opt))
+	}
+	return strings.Join(flags, space) + space
 }
 
 func writeSources(config *Config, b *strings.Builder) {

--- a/protogen_test.go
+++ b/protogen_test.go
@@ -17,7 +17,8 @@ func TestCanGenerateFromExampleConfig(t *testing.T) {
 	assert.NotEmpty(t, result)
 
 	assert.Contains(t, result, "-Iprotorepo-example")
-	assert.Contains(t, result, "--go_out=.gen-go")
+	assert.Contains(t, result, "--go_out=gen")
+	assert.Contains(t, result, "--go_opt=paths=source_relative")
 	assert.Contains(t, result, "--include_imports")
 	assert.Contains(t, result, "grpckit/accounts/user.proto")
 	assert.Contains(t, result, "grpckit/base.proto")


### PR DESCRIPTION
# Summary

Many plugins — `protoc-gen-go` included — allow you to pass options via an option flag. For go, this looks like `--go_opt`. ([reference doc](https://protobuf.dev/reference/go/go-generated/#package))

They can be specified many times. Breaking this out of `--go_out` is especially useful when overwriting one module, not to mention doing it ten times. 

```yml
plugins:
  - name: go
    args: paths=source_relative,Mpath/to/proto=github.com/foo/bar/gen/org/path/to/proto,Mpath/to/other/proto=github.com/foo/bar/gen/org/path/to/other/proto

# vs

plugins:
  - name: go
    opts:
      - paths=source_relative
      - Mpath/to/proto=github.com/foo/bar/gen/org/path/to/proto
      - Mpath/to/other/proto=github.com/foo/bar/gen/org/path/to/other/proto
```

The module rewriting is still a pain but much easier to manage than before. Until we migrate to buf, I have to edit many configs like this. Each can have 5-10 protos, and at least two plugins.

# Test Plan

The existing test case was broken, so I fixed and adjusted to work with this change. Tested in a codebase of my own to verify it works with variety of plugins supporting only `--plugin_out` in conjunction with modern ones.

```
➜ go test ./...
ok      github.com/grpckit/omniproto    (cached)

```